### PR TITLE
[UI] Add autocomplete to emercoin-qt's console window.

### DIFF
--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -12,6 +12,9 @@
 
 #include <QDialog>
 
+#include <QWidget>
+#include <QCompleter>
+
 class ClientModel;
 
 namespace Ui {
@@ -98,6 +101,8 @@ private:
     QStringList history;
     int historyPtr;
     NodeId cachedNodeid;
+
+    QCompleter *autoCompleter;
 };
 
 #endif // BITCOIN_QT_RPCCONSOLE_H

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -1043,6 +1043,17 @@ json_spirit::Value CRPCTable::execute(const std::string &strMethod, const json_s
     }
 }
 
+std::vector<std::string> CRPCTable::listCommands() const
+{
+    std::vector<std::string> commandList;
+    typedef std::map<std::string, const CRPCCommand*> commandMap;
+
+    std::transform( mapCommands.begin(), mapCommands.end(),
+                   std::back_inserter(commandList),
+                   boost::bind(&commandMap::value_type::first,_1) );
+    return commandList;
+}
+
 std::string HelpExampleCli(string methodname, string args){
     return "> emercoin-cli " + methodname + " " + args + "\n";
 }

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -106,6 +106,12 @@ public:
     std::string help(std::string name) const;
 
     /**
+    * Returns a list of registered commands
+    * @returns List of registered commands.
+    */
+    std::vector<std::string> listCommands() const;
+
+    /**
      * Execute a method.
      * @param method   Method to execute
      * @param params   Array of arguments (JSON objects)


### PR DESCRIPTION
#### What is the purpose of this pull request (PR)?
Adds autocomplete to the debug console window.
* Added listCommands() to CRPCTable
* Autocomplete init in RPCConsole::setClientModel()

Code forked from Bitcoin v0.12.99 [https://github.com/bitcoin/bitcoin]
Bitcoin commit hash: `ce7413fcb7d28bd72e5ade7dc9756504de766fc2`
Bitcoin commit hash: `ee1533e262e72d0b5aaae187ab9a37ba79c9cda7ss`

#### Any background context to help the reviewer?
Code forked from two Bitcoin pull requests:
[Bitcoin PR #7613](https://github.com/bitcoin/bitcoin/pull/7613)
[Bitcoin PR #7772](https://github.com/bitcoin/bitcoin/pull/7772)

#### Was this PR tested and how (if not, why)?
Yes, tested on Ubuntu 14.04.

#### Screenshots (if appropriate)
![Autocomplete](http://i.imgur.com/2C85vqh.png?1)
