### PR TITLE
Correct lower case spelling of 'coin' in 'Emercoin'

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2014 EmerCoin Developers
+Copyright (c) 2013-2014 Emercoin Developers
 Copyright (c) 2011-2012 PPCoin Developers
 Copyright (c) 2009-2012 Bitcoin Developers
 Copyright (c) 2009-2013 Namecoin Developers

--- a/X509/CA/ca.config
+++ b/X509/CA/ca.config
@@ -51,7 +51,7 @@ userId                 = optional	 # Reference to external info
  keyUsage=		nonRepudiation, digitalSignature, keyEncipherment
 
  nsCertType=		client, email
- nsComment=		"EmerCoin EMCSSL PKI"
+ nsComment=		"Emercoin EMCSSL PKI"
 
  authorityKeyIdentifier=keyid:always,issuer:always
 

--- a/X509/CA/ca_generate.sh
+++ b/X509/CA/ca_generate.sh
@@ -3,12 +3,12 @@ rm -f emcssl_ca.key emcssl_ca.crt
 
 openssl ecparam -genkey -name secp256k1 -out emcssl_ca.key
 openssl req -new -key emcssl_ca.key -out csr.pem \
-    -subj '/O=EmerCoin/OU=PKI/CN=EMCSSL/emailAddress=team@emercoin.com/UID=EMC'
+    -subj '/O=Emercoin/OU=PKI/CN=EMCSSL/emailAddress=team@emercoin.com/UID=EMC'
 openssl req -x509 -days 36500 -key emcssl_ca.key -in csr.pem \
     -out emcssl_ca.crt
 
 rm csr.pem
 
 #openssl req -new -newkey rsa:4096 -nodes -keyout emcssl_ca.key -x509 -days 36500 \
-#  -subj '/O=EmerCoin/OU=EMCSSL/CN=EMCSSL/emailAddress=team@emercoin.com/UID=EMC' \
+#  -subj '/O=Emercoin/OU=EMCSSL/CN=EMCSSL/emailAddress=team@emercoin.com/UID=EMC' \
 #  -out emcssl_ca.crt

--- a/X509/gen_crt.sh
+++ b/X509/gen_crt.sh
@@ -44,7 +44,7 @@ SHA256=${SHA256#'sha256 fingerprint='}
 echo $SHA256 >>$FNAME
 
 echo
-echo "Please, deposit into EmerCoin NVS pair:"
+echo "Please, deposit into Emercoin NVS pair:"
 echo "  Key:   ssl:$SERIAL"
 echo "  Value: sha256=$SHA256"
 

--- a/X509/gen_tpl.sh
+++ b/X509/gen_tpl.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-echo "   New EmerCoin WWW PKI Certificate generation"
+echo "   New Emercoin WWW PKI Certificate generation"
 echo 
 echo 
 echo " Please, answer to following questions."

--- a/X509/info_crypt.sh
+++ b/X509/info_crypt.sh
@@ -31,7 +31,7 @@ fi
 grep -v '^#' $FNAME | gzip -c -9 | openssl enc -aes-256-cbc -salt -out $OUTF -pass pass:$PASSW
 
 echo
-echo "Please, deposit into EmerCoin NVS pair:"
+echo "Please, deposit into Emercoin NVS pair:"
 echo "  Key:   info:$INDEX"
 
 echo "  Value: body of the file: $OUTF"

--- a/X509/infocard_example.info
+++ b/X509/infocard_example.info
@@ -39,5 +39,5 @@ Email		abdul@bubbleinflators.com
 WEB		http://www.bubbleinflators.com/superabdul
 Facebook	Abdul.KurbashiBey
 Twitter		AbdulKurbashiBey
-EMC	EdvJ7b7zPL6gj5f8VNfX6zmVcftb35sKX2	# EmerCoin payment address
+EMC	EdvJ7b7zPL6gj5f8VNfX6zmVcftb35sKX2	# Emercoin payment address
 BTC	1MkKuU78bikC2ACLspofQZnNb6Vz9AP1Np	# BitCoin payment address

--- a/X509/infocard_example_corp.info
+++ b/X509/infocard_example_corp.info
@@ -1,5 +1,5 @@
 #
-# This is example of corp InfoCard for EmerCoin Info system
+# This is example of corp InfoCard for Emercoin Info system
 # This card will be retrieved by reference to NVS from EMCSSL subsystem,
 # or imported by another card.
 #

--- a/X509/infocard_example_user.info
+++ b/X509/infocard_example_user.info
@@ -41,5 +41,5 @@ Email+		abdul@bubbleinflators.com
 +WEB		http://www.bubbleinflators.com/superabdul
 Facebook	Abdul.KurbashiBey
 Twitter		AbdulKurbashiBey
-EMC	EdvJ7b7zPL6gj5f8VNfX6zmVcftb35sKX2	# EmerCoin payment address
+EMC	EdvJ7b7zPL6gj5f8VNfX6zmVcftb35sKX2	# Emercoin payment address
 BTC	1MkKuU78bikC2ACLspofQZnNb6Vz9AP1Np	# BitCoin payment address

--- a/doc/README
+++ b/doc/README
@@ -1,6 +1,6 @@
-EmerCoin 0.3.7 BETA
+Emercoin 0.3.7 BETA
 
-Copyright (c) 2013-2015 EmerCoin Developers
+Copyright (c) 2013-2015 Emercoin Developers
 Distributed under the MIT/X11 software license, see the accompanying
 file license.txt or http://www.opensource.org/licenses/mit-license.php.
 This product includes software developed by the OpenSSL Project for use in
@@ -10,7 +10,7 @@ cryptographic software written by Eric Young (eay@cryptsoft.com).
 
 Intro
 -----
-EmerCoin is a free open source project derived from Emercoin, with
+Emercoin is a free open source project derived from Emercoin, with
 the goal of providing a long-term energy-efficient crypto-currency.
 Built on the foundation of Emercoin, innovations such as proof-of-stake
 help further advance the field of crypto-currency.
@@ -27,8 +27,8 @@ Unpack the files into a directory and run:
 The software automatically finds other nodes to connect to.  You can
 enable Universal Plug and Play (UPnP) with your router/firewall
 or forward port 6661 (TCP) to your computer so you can receive
-incoming connections.  EmerCoin works without incoming connections,
-but allowing incoming connections helps the EmerCoin network.
+incoming connections.  Emercoin works without incoming connections,
+but allowing incoming connections helps the Emercoin network.
 
 
 See the documentation/wiki at the emercoin website:

--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -1,6 +1,6 @@
-EmerCoin 0.3.7 BETA
+Emercoin 0.3.7 BETA
 
-Copyright (c) 2013-2015 EmerCoin Developers
+Copyright (c) 2013-2015 Emercoin Developers
 Distributed under the MIT/X11 software license, see the accompanying
 file license.txt or http://www.opensource.org/licenses/mit-license.php.
 This product includes software developed by the OpenSSL Project for use in
@@ -10,7 +10,7 @@ cryptographic software written by Eric Young (eay@cryptsoft.com).
 
 Intro
 -----
-EmerCoin is a free open source project derived from Emercoin, with
+Emercoin is a free open source project derived from Emercoin, with
 the goal of providing a long-term energy-efficient crypto-currency.
 Built on the foundation of Emercoin, innovations such as proof-of-stake
 help further advance the field of crypto-currency.
@@ -29,8 +29,8 @@ applications if necessary.
 The software automatically finds other nodes to connect to.  You can
 enable Universal Plug and Play (UPnP) with your router/firewall
 or forward port 6661 (TCP) to your computer so you can receive
-incoming connections.  EmerCoin works without incoming connections,
-but allowing incoming connections helps the EmerCoin network.
+incoming connections.  Emercoin works without incoming connections,
+but allowing incoming connections helps the Emercoin network.
 
 See the documentation/wiki at the emercoin website:
   http://www.emercoin.com/

--- a/share/setup.nsi
+++ b/share/setup.nsi
@@ -1,4 +1,4 @@
-Name EmerCoin
+Name Emercoin
 
 RequestExecutionLevel highest
 SetCompressor /SOLID lzma
@@ -6,7 +6,7 @@ SetCompressor /SOLID lzma
 # General Symbol Definitions
 !define REGKEY "SOFTWARE\$(^Name)"
 !define VERSION 0.3.7
-!define COMPANY "EmerCoin project"
+!define COMPANY "Emercoin project"
 !define URL http://www.emercoin.com/
 
 # MUI Symbol Definitions
@@ -19,7 +19,7 @@ SetCompressor /SOLID lzma
 !define MUI_STARTMENUPAGE_REGISTRY_ROOT HKLM
 !define MUI_STARTMENUPAGE_REGISTRY_KEY ${REGKEY}
 !define MUI_STARTMENUPAGE_REGISTRY_VALUENAME StartMenuGroup
-!define MUI_STARTMENUPAGE_DEFAULTFOLDER EmerCoin
+!define MUI_STARTMENUPAGE_DEFAULTFOLDER Emercoin
 !define MUI_FINISHPAGE_RUN $INSTDIR\emercoin-qt.exe
 !define MUI_UNICON "${NSISDIR}\Contrib\Graphics\Icons\modern-uninstall.ico"
 !define MUI_UNWELCOMEFINISHPAGE_BITMAP "../share/pixmaps/nsis-wizard.bmp"
@@ -46,13 +46,13 @@ Var StartMenuGroup
 
 # Installer attributes
 OutFile emercoin-0.3.7-win32-setup.exe
-InstallDir $PROGRAMFILES\EmerCoin
+InstallDir $PROGRAMFILES\Emercoin
 CRCCheck on
 XPStyle on
 BrandingText " "
 ShowInstDetails show
 VIProductVersion 0.3.7.0
-VIAddVersionKey ProductName EmerCoin
+VIAddVersionKey ProductName Emercoin
 VIAddVersionKey ProductVersion "${VERSION}"
 VIAddVersionKey CompanyName "${COMPANY}"
 VIAddVersionKey CompanyWebsite "${URL}"
@@ -87,8 +87,8 @@ Section -post SEC0001
     WriteUninstaller $INSTDIR\uninstall.exe
     !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
     CreateDirectory $SMPROGRAMS\$StartMenuGroup
-    CreateShortcut "$SMPROGRAMS\$StartMenuGroup\EmerCoin.lnk" $INSTDIR\emercoin-qt.exe
-    CreateShortcut "$SMPROGRAMS\$StartMenuGroup\Uninstall EmerCoin.lnk" $INSTDIR\uninstall.exe
+    CreateShortcut "$SMPROGRAMS\$StartMenuGroup\Emercoin.lnk" $INSTDIR\emercoin-qt.exe
+    CreateShortcut "$SMPROGRAMS\$StartMenuGroup\Uninstall Emercoin.lnk" $INSTDIR\uninstall.exe
     !insertmacro MUI_STARTMENU_WRITE_END
     WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayName "$(^Name)"
     WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayVersion "${VERSION}"
@@ -131,9 +131,9 @@ SectionEnd
 
 Section -un.post UNSEC0001
     DeleteRegKey HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)"
-    Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\Uninstall EmerCoin.lnk"
-    Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\EmerCoin.lnk"
-    Delete /REBOOTOK "$SMSTARTUP\EmerCoin.lnk"
+    Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\Uninstall Emercoin.lnk"
+    Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\Emercoin.lnk"
+    Delete /REBOOTOK "$SMSTARTUP\Emercoin.lnk"
     Delete /REBOOTOK $INSTDIR\uninstall.exe
     Delete /REBOOTOK $INSTDIR\debug.log
     Delete /REBOOTOK $INSTDIR\db.log

--- a/src/base58.h
+++ b/src/base58.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin Developers
 // Copyright (c) 2011-2012 The PPCoin developers
-// Copyright (c) 2013-2014 The EmerCoin developers
+// Copyright (c) 2013-2014 The Emercoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Copyright (c) 2011-2013 The PPCoin developers
-// Copyright (c) 2013-2014 The EmerCoin developers
+// Copyright (c) 2013-2014 The Emercoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -2171,10 +2171,10 @@ Value getwork(const Array& params, bool fHelp)
             "If [data] is specified, tries to solve the block and returns true if it was successful.");
 
     if (vNodes.empty())
-        throw JSONRPCError(-9, "EmerCoin is not connected!");
+        throw JSONRPCError(-9, "Emercoin is not connected!");
 
     if (IsInitialBlockDownload())
-        throw JSONRPCError(-10, "EmerCoin is downloading blocks...");
+        throw JSONRPCError(-10, "Emercoin is downloading blocks...");
 
     typedef map<uint256, pair<CBlock*, CScript> > mapNewBlock_t;
     static mapNewBlock_t mapNewBlock;
@@ -2302,10 +2302,10 @@ Value getblocktemplate(const Array& params, bool fHelp)
         throw JSONRPCError(-8, "Invalid mode");
 
     if (vNodes.empty())
-        throw JSONRPCError(-9, "EmerCoin is not connected!");
+        throw JSONRPCError(-9, "Emercoin is not connected!");
 
     if (IsInitialBlockDownload())
-        throw JSONRPCError(-10, "EmerCoin is downloading blocks...");
+        throw JSONRPCError(-10, "Emercoin is downloading blocks...");
 
     static CReserveKey reservekey(pwalletMain);
 

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Copyright (c) 2011-2013 The PPCoin developers
-// Copyright (c) 2013-2014 The EmerCoin developers
+// Copyright (c) 2013-2014 The Emercoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/emcdns.cpp
+++ b/src/emcdns.cpp
@@ -1,5 +1,5 @@
 /*
- * Simple DNS server for EmerCoin project
+ * Simple DNS server for Emercoin project
  *
  * Lookup for names like "dns:some-nake" in the local nameindex database.
  * Database is updates from blockchain, and keeps NMC-transactions.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Copyright (c) 2011-2013 The PPCoin developers
-// Copyright (c) 2013-2014 The EmerCoin developers
+// Copyright (c) 2013-2014 The Emercoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include "db.h"
@@ -81,7 +81,7 @@ void Shutdown(void* parg)
         delete pwalletMain;
         CreateThread(ExitTimeout, NULL);
         Sleep(50);
-        printf("EmerCoin exiting\n\n");
+        printf("Emercoin exiting\n\n");
         fExit = true;
 #ifndef QT_GUI
         // ensure non UI client get's exited here, but let Emercoin-Qt reach return 0; in bitcoin.cpp
@@ -183,7 +183,7 @@ bool AppInit2(int argc, char* argv[])
     if (mapArgs.count("-?") || mapArgs.count("--help"))
     {
         string strUsage = string() +
-          _("EmerCoin version") + " " + FormatFullVersion() + "\n\n" +
+          _("Emercoin version") + " " + FormatFullVersion() + "\n\n" +
           _("Usage:") + "\t\t\t\t\t\t\t\t\t\t\n" +
             "  emercoind [options]                   \t  " + "\n" +
             "  emercoind [options] <command> [params]\t  " + _("Send command to -server or emercoind") + "\n" +
@@ -331,7 +331,7 @@ bool AppInit2(int argc, char* argv[])
     if (!fDebug)
         ShrinkDebugFile();
     printf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
-    printf("EmerCoin version %s (%s)\n", FormatFullVersion().c_str(), CLIENT_DATE.c_str());
+    printf("Emercoin version %s (%s)\n", FormatFullVersion().c_str(), CLIENT_DATE.c_str());
     printf("Default data directory %s\n", GetDefaultDataDir().string().c_str());
 
     if (GetBoolArg("-loadblockindextest"))
@@ -349,7 +349,7 @@ bool AppInit2(int argc, char* argv[])
     static boost::interprocess::file_lock lock(pathLockFile.string().c_str());
     if (!lock.try_lock())
     {
-        ThreadSafeMessageBox(strprintf(_("Cannot obtain a lock on data directory %s.  EmerCoin is probably already running."), GetDataDir().string().c_str()), _("EmerCoin"), wxOK|wxMODAL);
+        ThreadSafeMessageBox(strprintf(_("Cannot obtain a lock on data directory %s.  Emercoin is probably already running."), GetDataDir().string().c_str()), _("Emercoin"), wxOK|wxMODAL);
         return false;
     }
 
@@ -397,12 +397,12 @@ bool AppInit2(int argc, char* argv[])
         if (nLoadWalletRet == DB_CORRUPT)
             strErrors << _("Error loading wallet.dat: Wallet corrupted") << "\n";
         else if (nLoadWalletRet == DB_TOO_NEW)
-            strErrors << _("Error loading wallet.dat: Wallet requires newer version of EmerCoin") << "\n";
+            strErrors << _("Error loading wallet.dat: Wallet requires newer version of Emercoin") << "\n";
         else if (nLoadWalletRet == DB_NEED_REWRITE)
         {
-            strErrors << _("Wallet needed to be rewritten: restart EmerCoin to complete") << "\n";
+            strErrors << _("Wallet needed to be rewritten: restart Emercoin to complete") << "\n";
             printf("%s", strErrors.str().c_str());
-            ThreadSafeMessageBox(strErrors.str(), _("EmerCoin"), wxOK | wxICON_ERROR | wxMODAL);
+            ThreadSafeMessageBox(strErrors.str(), _("Emercoin"), wxOK | wxICON_ERROR | wxMODAL);
             return false;
         }
         else
@@ -474,7 +474,7 @@ bool AppInit2(int argc, char* argv[])
 
     if (!strErrors.str().empty())
     {
-        ThreadSafeMessageBox(strErrors.str(), _("EmerCoin"), wxOK | wxICON_ERROR | wxMODAL);
+        ThreadSafeMessageBox(strErrors.str(), _("Emercoin"), wxOK | wxICON_ERROR | wxMODAL);
         return false;
     }
 
@@ -537,7 +537,7 @@ bool AppInit2(int argc, char* argv[])
         addrProxy = CService(mapArgs["-proxy"], 9050);
         if (!addrProxy.IsValid())
         {
-            ThreadSafeMessageBox(_("Invalid -proxy address"), _("EmerCoin"), wxOK | wxMODAL);
+            ThreadSafeMessageBox(_("Invalid -proxy address"), _("Emercoin"), wxOK | wxMODAL);
             return false;
         }
     }
@@ -568,7 +568,7 @@ bool AppInit2(int argc, char* argv[])
         std::string strError;
         if (!BindListenPort(strError))
         {
-            ThreadSafeMessageBox(strError, _("EmerCoin"), wxOK | wxMODAL);
+            ThreadSafeMessageBox(strError, _("Emercoin"), wxOK | wxMODAL);
             return false;
         }
     }
@@ -588,11 +588,11 @@ bool AppInit2(int argc, char* argv[])
     {
         if (!ParseMoney(mapArgs["-paytxfee"], nTransactionFee) || nTransactionFee < MIN_TX_FEE)
         {
-            ThreadSafeMessageBox(_("Invalid amount for -paytxfee=<amount>"), _("EmerCoin"), wxOK | wxMODAL);
+            ThreadSafeMessageBox(_("Invalid amount for -paytxfee=<amount>"), _("Emercoin"), wxOK | wxMODAL);
             return false;
         }
         if (nTransactionFee > 0.25 * COIN)
-            ThreadSafeMessageBox(_("Warning: -paytxfee is set very high.  This is the transaction fee you will pay if you send a transaction."), _("EmerCoin"), wxOK | wxICON_EXCLAMATION | wxMODAL);
+            ThreadSafeMessageBox(_("Warning: -paytxfee is set very high.  This is the transaction fee you will pay if you send a transaction."), _("Emercoin"), wxOK | wxICON_EXCLAMATION | wxMODAL);
     }
 
     if (mapArgs.count("-reservebalance")) // ppcoin: reserve balance amount
@@ -600,7 +600,7 @@ bool AppInit2(int argc, char* argv[])
         int64 nReserveBalance = 0;
         if (!ParseMoney(mapArgs["-reservebalance"], nReserveBalance))
         {
-            ThreadSafeMessageBox(_("Invalid amount for -reservebalance=<amount>"), _("EmerCoin"), wxOK | wxMODAL);
+            ThreadSafeMessageBox(_("Invalid amount for -reservebalance=<amount>"), _("Emercoin"), wxOK | wxMODAL);
             return false;
         }
     }
@@ -608,7 +608,7 @@ bool AppInit2(int argc, char* argv[])
     if (mapArgs.count("-checkpointkey")) // ppcoin: checkpoint master priv key
     {
         if (!Checkpoints::SetCheckpointPrivKey(GetArg("-checkpointkey", "")))
-            ThreadSafeMessageBox(_("Unable to sign checkpoint, wrong checkpointkey?\n"), _("EmerCoin"), wxOK | wxMODAL);
+            ThreadSafeMessageBox(_("Unable to sign checkpoint, wrong checkpointkey?\n"), _("Emercoin"), wxOK | wxMODAL);
         else printf("Setting private key is.... successful\n");
     }
 
@@ -621,7 +621,7 @@ bool AppInit2(int argc, char* argv[])
     RandAddSeedPerfmon();
 
     if (!CreateThread(StartNode, NULL))
-        ThreadSafeMessageBox(_("Error: CreateThread(StartNode) failed"), _("EmerCoin"), wxOK | wxMODAL);
+        ThreadSafeMessageBox(_("Error: CreateThread(StartNode) failed"), _("Emercoin"), wxOK | wxMODAL);
 
     if (fServer)
         CreateThread(ThreadRPCServer, NULL);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Copyright (c) 2011-2013 The PPCoin developers
-// Copyright (c) 2013-2014 The EmerCoin developers
+// Copyright (c) 2013-2014 The Emercoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -2300,7 +2300,7 @@ bool CheckDiskSpace(uint64 nAdditionalBytes)
         string strMessage = _("Warning: Disk space is low");
         strMiscWarning = strMessage;
         printf("*** %s\n", strMessage.c_str());
-        ThreadSafeMessageBox(strMessage, "EmerCoin", wxOK | wxICON_EXCLAMATION | wxMODAL);
+        ThreadSafeMessageBox(strMessage, "Emercoin", wxOK | wxICON_EXCLAMATION | wxMODAL);
         StartShutdown();
         return false;
     }
@@ -2361,7 +2361,7 @@ bool LoadBlockIndex(bool fAllowNew)
     }
 
     printf("%s Network: genesis=0x%s nBitsLimit=0x%08x nBitsInitial=0x%08x nStakeMinAge=%d nCoinbaseMaturity=%d nModifierInterval=%d\n",
-           fTestNet? "Test" : "EmerCoin", hashGenesisBlock.ToString().substr(0, 20).c_str(), bnProofOfWorkLimit.GetCompact(), bnInitialHashTarget.GetCompact(), nStakeMinAge, nCoinbaseMaturity, nModifierInterval);
+           fTestNet? "Test" : "Emercoin", hashGenesisBlock.ToString().substr(0, 20).c_str(), bnProofOfWorkLimit.GetCompact(), bnInitialHashTarget.GetCompact(), nStakeMinAge, nCoinbaseMaturity, nModifierInterval);
 
     //
     // Load block index

--- a/src/main.h
+++ b/src/main.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Copyright (c) 2011-2013 The PPCoin developers
-// Copyright (c) 2013-2014 The EmerCoin developers
+// Copyright (c) 2013-2014 The Emercoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef BITCOIN_MAIN_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Copyright (c) 2011-2013 The PPCoin developers
-// Copyright (c) 2013-2014 The EmerCoin developers
+// Copyright (c) 2013-2014 The Emercoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -897,7 +897,7 @@ void ThreadMapPort2(void* parg)
             }
         }
 
-        string strDesc = "EmerCoin " + FormatFullVersion();
+        string strDesc = "Emercoin " + FormatFullVersion();
 #ifndef UPNPDISCOVER_SUCCESS
         /* miniupnpc 1.5 */
         r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype,
@@ -1516,7 +1516,7 @@ bool BindListenPort(string& strError)
     {
         int nErr = WSAGetLastError();
         if (nErr == WSAEADDRINUSE)
-            strError = strprintf(_("Unable to bind to port %d on this computer.  EmerCoin is probably already running."), ntohs(sockaddr.sin_port));
+            strError = strprintf(_("Unable to bind to port %d on this computer.  Emercoin is probably already running."), ntohs(sockaddr.sin_port));
         else
             strError = strprintf("Error: Unable to bind to port %d on this computer (bind returned error %d)", ntohs(sockaddr.sin_port), nErr);
         printf("%s\n", strError.c_str());

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin developers
-// Copyright (c) 2013-2014 The EmerCoin developers
+// Copyright (c) 2013-2014 The Emercoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -172,12 +172,12 @@ int main(int argc, char *argv[])
 
     // Application identification (must be set before OptionsModel is initialized,
     // as it is used to locate QSettings)
-    app.setOrganizationName("EmerCoin");
+    app.setOrganizationName("Emercoin");
     app.setOrganizationDomain("emercoin.com");
     if(GetBoolArg("-testnet")) // Separate UI settings for testnet
-        app.setApplicationName("EmerCoin-Qt-testnet");
+        app.setApplicationName("Emercoin-Qt-testnet");
     else
-        app.setApplicationName("EmerCoin-Qt");
+        app.setApplicationName("Emercoin-Qt");
 
     // ... then GUI settings:
     OptionsModel optionsModel;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -72,7 +72,7 @@ EmercoinGUI::EmercoinGUI(QWidget *parent):
     rpcConsole(0)
 {
     resize(850, 550);
-    setWindowTitle(tr("EmerCoin Wallet"));
+    setWindowTitle(tr("Emercoin Wallet"));
 #ifndef Q_WS_MAC
     setWindowIcon(QIcon(":icons/ppcoin"));
 #else
@@ -247,7 +247,7 @@ void EmercoinGUI::createActions()
     quitAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q));
     quitAction->setMenuRole(QAction::QuitRole);
     aboutAction = new QAction(QIcon(":/icons/ppcoin"), tr("&About %1").arg(qApp->applicationName()), this);
-    aboutAction->setToolTip(tr("Show information about EmerCoin"));
+    aboutAction->setToolTip(tr("Show information about Emercoin"));
     aboutAction->setMenuRole(QAction::AboutRole);
     aboutQtAction = new QAction(tr("About &Qt"), this);
     aboutQtAction->setToolTip(tr("Show information about Qt"));
@@ -255,8 +255,8 @@ void EmercoinGUI::createActions()
     optionsAction = new QAction(QIcon(":/icons/options"), tr("&Options..."), this);
     optionsAction->setToolTip(tr("Modify configuration options for emercoin"));
     optionsAction->setMenuRole(QAction::PreferencesRole);
-    toggleHideAction = new QAction(QIcon(":/icons/ppcoin"), tr("Show/Hide &EmerCoin"), this);
-    toggleHideAction->setToolTip(tr("Show or hide the EmerCoin window"));
+    toggleHideAction = new QAction(QIcon(":/icons/ppcoin"), tr("Show/Hide &Emercoin"), this);
+    toggleHideAction->setToolTip(tr("Show or hide the Emercoin window"));
     exportAction = new QAction(QIcon(":/icons/export"), tr("&Export..."), this);
     exportAction->setToolTip(tr("Export the data in the current tab to a file"));
     encryptWalletAction = new QAction(QIcon(":/icons/lock_closed"), tr("&Encrypt Wallet"), this);
@@ -405,7 +405,7 @@ void EmercoinGUI::createTrayIcon()
     trayIcon = new QSystemTrayIcon(this);
     trayIconMenu = new QMenu(this);
     trayIcon->setContextMenu(trayIconMenu);
-    trayIcon->setToolTip(tr("EmerCoin client"));
+    trayIcon->setToolTip(tr("Emercoin client"));
     trayIcon->setIcon(QIcon(":/icons/toolbar"));
     connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
             this, SLOT(trayIconActivated(QSystemTrayIcon::ActivationReason)));
@@ -498,7 +498,7 @@ void EmercoinGUI::setNumConnections(int count)
     default: icon = ":/icons/connect_4"; break;
     }
     labelConnectionsIcon->setPixmap(QIcon(icon).pixmap(STATUSBAR_ICONSIZE,STATUSBAR_ICONSIZE));
-    labelConnectionsIcon->setToolTip(tr("%n active connection(s) to EmerCoin network", "", count));
+    labelConnectionsIcon->setToolTip(tr("%n active connection(s) to Emercoin network", "", count));
 }
 
 void EmercoinGUI::setNumBlocks(int count)

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -45,9 +45,9 @@ QString BitcoinUnits::description(int unit)
 {
     switch(unit)
     {
-    case BTC: return QString("EmerCoins");
-    case mBTC: return QString("Milli-EmerCoins (1 / 1,000)");
-    case uBTC: return QString("Micro-EmerCoins (1 / 1,000,000)");
+    case BTC: return QString("Emercoins");
+    case mBTC: return QString("Milli-Emercoins (1 / 1,000)");
+    case uBTC: return QString("Micro-Emercoins (1 / 1,000,000)");
     default: return QString("???");
     }
 }

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>About EmerCoin</string>
+   <string>About Emercoin</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2">
    <item>
@@ -50,7 +50,7 @@
        <item>
         <widget class="QLabel" name="label">
          <property name="text">
-          <string>&lt;b&gt;EmerCoin&lt;/b&gt; version</string>
+          <string>&lt;b&gt;Emercoin&lt;/b&gt; version</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -22,7 +22,7 @@ SendCoinsEntry::SendCoinsEntry(QWidget *parent) :
 #endif
 
 #if QT_VERSION >= 0x040700
-    ui->payTo->setPlaceholderText(tr("Enter a EmerCoin address or name"));
+    ui->payTo->setPlaceholderText(tr("Enter a Emercoin address or name"));
     ui->addAsLabel->setPlaceholderText(tr("Enter a label for this address to add it to your address book"));
 #endif
     setFocusPolicy(Qt::TabFocus);

--- a/src/uint256hm.h
+++ b/src/uint256hm.h
@@ -1,6 +1,6 @@
 /*
  * HashMap container for uint256 index -> value
- * Part of EmerCoin project.
+ * Part of Emercoin project.
  *
  */
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Copyright (c) 2011-2012 The PPCoin developers
-// Copyright (c) 2013-2014 The EmerCoin developers
+// Copyright (c) 2013-2014 The Emercoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -854,12 +854,12 @@ boost::filesystem::path GetDefaultDataDir()
 {
     namespace fs = boost::filesystem;
 
-    // Windows: C:\Documents and Settings\username\Application Data\EmerCoin
-    // Mac: ~/Library/Application Support/EmerCoin
+    // Windows: C:\Documents and Settings\username\Application Data\Emercoin
+    // Mac: ~/Library/Application Support/Emercoin
     // Unix: ~/.emercoin
 #ifdef WIN32
     // Windows
-    return MyGetSpecialFolderPath(CSIDL_APPDATA, true) / "EmerCoin";
+    return MyGetSpecialFolderPath(CSIDL_APPDATA, true) / "Emercoin";
 #else
     fs::path pathRet;
     char* pszHome = getenv("HOME");
@@ -871,7 +871,7 @@ boost::filesystem::path GetDefaultDataDir()
     // Mac
     pathRet /= "Library/Application Support";
     fs::create_directory(pathRet);
-    return pathRet / "EmerCoin";
+    return pathRet / "Emercoin";
 #else
     // Unix
     return pathRet / ".emercoin";
@@ -1073,10 +1073,10 @@ void AddTimeData(const CNetAddr& ip, int64 nTime)
                 if (!fMatch)
                 {
                     fDone = true;
-                    string strMessage = _("Warning: Please check that your computer's date and time are correct.  If your clock is wrong EmerCoin will not work properly.");
+                    string strMessage = _("Warning: Please check that your computer's date and time are correct.  If your clock is wrong Emercoin will not work properly.");
                     strMiscWarning = strMessage;
                     printf("*** %s\n", strMessage.c_str());
-                    ThreadSafeMessageBox(strMessage+" ", string("EmerCoin"), wxOK | wxICON_EXCLAMATION);
+                    ThreadSafeMessageBox(strMessage+" ", string("Emercoin"), wxOK | wxICON_EXCLAMATION);
                 }
             }
         }
@@ -1124,7 +1124,7 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
 #ifdef WIN32
 boost::filesystem::path static StartupShortcutPath()
 {
-    return MyGetSpecialFolderPath(CSIDL_STARTUP, true) / "EmerCoin.lnk";
+    return MyGetSpecialFolderPath(CSIDL_STARTUP, true) / "Emercoin.lnk";
 }
 
 bool GetStartOnSystemStartup()
@@ -1246,7 +1246,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
         // Write a emercoin.desktop file to the autostart directory:
         optionFile << "[Desktop Entry]\n";
         optionFile << "Type=Application\n";
-        optionFile << "Name=EmerCoin\n";
+        optionFile << "Name=Emercoin\n";
         optionFile << "Exec=" << pszExePath << " -min\n";
         optionFile << "Terminal=false\n";
         optionFile << "Hidden=false\n";


### PR DESCRIPTION
Corrects lower case spelling of 'coin' in 'Emercoin', for consistency.

Originally requested in [other repro](https://github.com/EvgenijM86/emercoin/pull/7).

Thanks.