### PR TITLE
Fix Incorrect Definition

### DIFF
--- a/src/pow.h
+++ b/src/pow.h
@@ -12,7 +12,7 @@ class CBlockHeader;
 class CBlockIndex;
 class uint256;
 
-const CBlockIndex *GetLastBlockIndex(const CBlockIndex* pindex, bool fProofOfStake);
+const CBlockIndex* GetLastBlockIndex(const CBlockIndex* pindex, bool fProofOfStake);
 unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfStake);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */


### PR DESCRIPTION
const CBlockIndex is correctly defined in pow.cpp but not here in the header.