### PR TITLE
Show coins as available once confirmed

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -214,7 +214,7 @@ void TransactionRecord::updateStatus(const CWalletTx &wtx)
         }
     }
     // For generated transactions, determine maturity
-    else if(type == TransactionRecord::Generated || type == TransactionRecord::StakeMint)
+    else if(type == TransactionRecord::Generated) 
     {
         if (wtx.GetBlocksToMaturity() > 0)
         {


### PR DESCRIPTION
Confirmed but non-mature coins were not showing as available to be spent. Now once coins confirm they will show as spendable/available.