### PR TITLE
Sort transactions view after model reset

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -48,7 +48,7 @@ struct TransactionView::TableView: public QTableView{
         setSelectionBehavior(QAbstractItemView::SelectRows);
         setSelectionMode(QAbstractItemView::ExtendedSelection);
         setSortingEnabled(true);
-        sortByColumn(TransactionTableModel::Date, Qt::DescendingOrder);
+        sortDefault();
         verticalHeader()->hide();
 
         setColumnWidth(TransactionTableModel::Status, STATUS_COLUMN_WIDTH);
@@ -56,6 +56,9 @@ struct TransactionView::TableView: public QTableView{
         setColumnWidth(TransactionTableModel::Date, DATE_COLUMN_WIDTH);
         setColumnWidth(TransactionTableModel::Type, TYPE_COLUMN_WIDTH);
         setColumnWidth(TransactionTableModel::Amount, AMOUNT_MINIMUM_COLUMN_WIDTH);
+    }
+    void sortDefault() {
+        sortByColumn(TransactionTableModel::Date, Qt::DescendingOrder);
     }
     QString format(CAmount amount)const {
         return BitcoinUnits::format(_walletModel->getOptionsModel()->getDisplayUnit(), amount, false, BitcoinUnits::separatorAlways);
@@ -251,6 +254,7 @@ void TransactionView::setModel(WalletModel *_model)
     transactionProxyModel->setSortRole(Qt::EditRole);
 
     transactionView->setModel(transactionProxyModel);
+    transactionView->sortDefault();
 
     columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(transactionView, AMOUNT_MINIMUM_COLUMN_WIDTH, MINIMUM_COLUMN_WIDTH, this);
 


### PR DESCRIPTION
There was a bug reported that transactions were not sorted afer program startup.