### PR TITLE
Splash screen pixmap: prevent multiple resizing

### DIFF
--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -84,7 +84,7 @@ NetworkStyle::NetworkStyle(const QString &_appName, const int iconColorHueShift,
 
     appIcon             = QIcon(pixmap);
     trayAndWindowIcon   = QIcon(pixmap.scaled(QSize(256,256)));
-    startScreenIcon     = QIcon(splash);
+    startScreenIcon     = splash;
 }
 
 const NetworkStyle *NetworkStyle::instantiate(const QString &networkId)

--- a/src/qt/networkstyle.h
+++ b/src/qt/networkstyle.h
@@ -19,7 +19,7 @@ public:
     const QString &getAppName() const { return appName; }
     const QIcon &getAppIcon() const { return appIcon; }
     const QIcon &getTrayAndWindowIcon() const { return trayAndWindowIcon; }
-    const QIcon &getStartScreenIcon() const { return startScreenIcon; }
+    const QPixmap &getStartScreenIcon() const { return startScreenIcon; }
     const QString &getTitleAddText() const { return titleAddText; }
 
 private:
@@ -29,7 +29,7 @@ private:
     QString appName;
     QIcon appIcon;
     QIcon trayAndWindowIcon;
-    QIcon startScreenIcon;
+    QPixmap startScreenIcon;
     QString titleAddText;
 };
 

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -68,13 +68,8 @@ SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) 
     QRect rGradient(QPoint(0,0), splashSize);
     pixPaint.fillRect(rGradient, gradient);
 
-    // draw the bitcoin icon, expected size of PNG: 1024x1024
-    QRect rectIcon(QPoint(0,0), QSize(266,322));
-
-    const QSize requiredSize(439,532);
-    QPixmap icon(networkStyle->getStartScreenIcon().pixmap(requiredSize));
-
-    pixPaint.drawPixmap(rectIcon, icon);
+    // draw the emercoin logo
+    pixPaint.drawPixmap(0, 0, networkStyle->getStartScreenIcon());
 
     // check font size and drawing with
     pixPaint.setFont(QFont(font, 33*fontFactor));


### PR DESCRIPTION
If painted icon has size not equal with what is needed, we should ask designers to draw splash screen.png in proper size and not to scale it by ourself.