### PR TITLE
ManageDnsPage refactoring

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -133,7 +133,6 @@ QT_MOC_CPP = \
   qt/moc_macdockiconhandler.cpp \
   qt/moc_macnotificationhandler.cpp \
   qt/moc_managenamespage.cpp \
-  qt/moc_ManageDnsPage.cpp \
   qt/moc_nametablemodel.cpp \
   qt/moc_modaloverlay.cpp \
   qt/moc_notificator.cpp \
@@ -205,6 +204,8 @@ BITCOIN_QT_H = \
   qt/macnotificationhandler.h \
   qt/managenamespage.h \
   qt/ManageDnsPage.h \
+  qt/NameValueLineEdits.h \
+  qt/SelectableLineEdit.h \
   qt/IPv4LineEdit.h \
   qt/IPv6LineEdit.h \
   qt/nametablemodel.h \
@@ -341,6 +342,8 @@ BITCOIN_QT_WALLET_CPP = \
   qt/editaddressdialog.cpp \
   qt/managenamespage.cpp \
   qt/ManageDnsPage.cpp \
+  qt/NameValueLineEdits.cpp \
+  qt/SelectableLineEdit.cpp \
   qt/IPv4LineEdit.cpp \
   qt/IPv4LineEdit.cpp \
   qt/nametablemodel.cpp \

--- a/src/qt/ManageDnsPage.h
+++ b/src/qt/ManageDnsPage.h
@@ -2,27 +2,21 @@
 #pragma once
 #include <QDialog>
 #include <QLineEdit>
+#include "NameValueLineEdits.h"
 class QLineEdit;
 class QFormLayout;
 class QString;
 
 class ManageDnsPage: public QDialog {
-    Q_OBJECT
     public:
-	    ManageDnsPage(QWidget*parent);
-
-        QLineEdit* _editName = 0;
-        struct LineEdit: public QLineEdit {
-            QString _dnsRecord;
-        };
-        QList<LineEdit*> _edits;
-
-        QLineEdit* _resultingName = 0;
-        QLineEdit* _resultingValue = 0;
-    Q_SIGNALS:
-        void previewName(const QString & s);
-        void previewValue(const QString & s);
+	    ManageDnsPage(QWidget*parent=0);
+		QString name()const;
+		QString value()const;
     protected:
-        void recalcValue();
-        LineEdit* addLineEdit(QFormLayout*form, QString dnsParam, QString text, QString tooltipq);
+		NameValueLineEdits* _NVPair = 0;
+		QLineEdit* _editName = 0;
+		QList<QLineEdit*> _edits;
+
+		void recalcValue();
+		QLineEdit* addLineEdit(QFormLayout*form, const QString& dnsParam, const QString& text, const QString& tooltip);
 };

--- a/src/qt/NameValueLineEdits.cpp
+++ b/src/qt/NameValueLineEdits.cpp
@@ -1,0 +1,144 @@
+﻿//NameValueLineEdits.cpp by Emercoin developers
+#include "NameValueLineEdits.h"
+#include <QPlainTextEdit>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QToolButton>
+#include <QApplication>
+#include <QClipboard>
+#include <QToolTip>
+#include <QLabel>
+
+class SelectableTextEdit: public QPlainTextEdit {
+	public:
+		SelectableTextEdit() {}
+
+		QPointer<QWidget> _buddyToShowToolip;//use this window if not set
+		virtual void mousePressEvent(QMouseEvent *e)override {
+			QPlainTextEdit::mousePressEvent(e);
+			if(isReadOnly())
+				selectAll();
+		}
+		void copyAndShowTooltip(QLineEdit*toDeselect = 0) {
+			if(toDeselect)
+				toDeselect->deselect();
+			selectAll();
+			QApplication::clipboard()->setText(toPlainText());
+			QWidget* wNear = _buddyToShowToolip;
+			if(!wNear)
+				wNear = this;
+			auto pt = wNear->rect().bottomLeft();
+			QToolTip::showText(wNear->mapToGlobal(pt), tr("Copied"));
+		}
+};
+NameValueLineEdits::NameValueLineEdits() {
+	_resultingName = new SelectableLineEdit;
+    _resultingValue = new SelectableLineEdit;
+	_resultingMultiline = new SelectableTextEdit;
+
+	auto form = new QFormLayout(this);
+	form->setMargin(0);//usually this widget is embedded to other so no need
+	form->addRow(new QLabel(tr("If you have filled in all the fields, open Emercoin wallet and copy value below in emercoin blockchain ('Manage names' tab in wallet):")));
+	{
+		auto w = new QWidget;
+		auto lay = new QHBoxLayout(w);
+		lay->setSpacing(0);
+		lay->setMargin(0);
+		
+		QString namePlaceholder = tr("This field will contain name to insert to 'Manage names' panel");
+        _resultingName->setPlaceholderText(namePlaceholder);
+		_resultingName->setToolTip(tr("Read-only") + ". " +  namePlaceholder);
+		_resultingName->setReadOnly(true);
+		lay->addWidget(_resultingName);
+		
+		auto copy = new QToolButton;
+		copy->setText(tr("Copy to clipboard"));
+		_resultingName->_buddyToShowToolip = copy;
+		connect(copy, &QAbstractButton::clicked, this, [=] () {
+			_resultingName->copyAndShowTooltip(_resultingValue);
+		});
+		lay->addWidget(copy);
+		form->addRow(tr("Name:"), w);
+	}
+	auto layValue = new QVBoxLayout;
+	{
+		_w1Line = new QWidget;
+		auto lay = new QHBoxLayout(_w1Line);
+		lay->setSpacing(0);
+		lay->setMargin(0);
+
+		_resultingValue->setReadOnly(true);
+        _resultingValue->setPlaceholderText(tr("This field will contain value to insert to 'Manage names' panel"));
+		lay->addWidget(_resultingValue);
+
+		auto copy = new QToolButton;
+		copy->setText(tr("Copy to clipboard"));
+		connect(copy, &QAbstractButton::clicked, this, [=]() {
+			_resultingValue->copyAndShowTooltip(_resultingName);
+		});
+		lay->addWidget(copy);
+		layValue->addWidget(_w1Line);
+	}
+	{
+		_wMultiLine = new QWidget;
+		auto lay = new QHBoxLayout(_wMultiLine);
+		lay->setSpacing(0);
+		lay->setMargin(0);
+
+		_resultingMultiline->setReadOnly(true);
+        _resultingMultiline->setPlaceholderText(tr("This field will contain value to insert to 'Manage names' panel"));
+		lay->addWidget(_resultingMultiline);
+
+		auto copy = new QToolButton;
+		copy->setText(tr("Copy to clipboard"));
+		_resultingMultiline->_buddyToShowToolip = copy;
+		connect(copy, &QAbstractButton::clicked, this, [=]() {
+			_resultingMultiline->copyAndShowTooltip(_resultingName);
+		});
+		lay->addWidget(copy);
+		layValue->addWidget(_wMultiLine);
+	}
+	form->addRow(tr("Value:"), layValue);
+	if(_multiline)
+		_w1Line->hide();
+	else
+		_wMultiLine->hide();
+}
+void NameValueLineEdits::setName(const QString & s) {
+	_resultingName->setText(s);
+}
+void NameValueLineEdits::setValuePlaceholder(const QString & s) {
+	_resultingValue->setPlaceholderText(s);
+	_resultingMultiline->setPlaceholderText(s);
+}
+void NameValueLineEdits::copyValue() {
+	if(_multiline) {
+		_resultingMultiline->copyAndShowTooltip(_resultingName);
+		return;
+	}
+	_resultingValue->copyAndShowTooltip(_resultingName);
+}
+void NameValueLineEdits::setValue(const QString & s) {
+	_resultingValue->setText(s);
+	_resultingMultiline->setPlainText(s);
+}
+void NameValueLineEdits::setValueMultiline(bool multi) {
+	if(_multiline==multi)
+		return;
+	_multiline = multi;
+	_wMultiLine->setVisible(_multiline);
+	_w1Line->setVisible(!_multiline);
+}
+void NameValueLineEdits::setValueReadOnly(bool b) {
+	_resultingValue->setReadOnly(b);
+	_resultingMultiline->setReadOnly(b);
+}
+QString NameValueLineEdits::name()const {
+	return _resultingName->text();
+}
+QString NameValueLineEdits::value()const {
+	if(_multiline)
+		return _resultingMultiline->toPlainText();
+	return _resultingValue->text();
+}

--- a/src/qt/NameValueLineEdits.h
+++ b/src/qt/NameValueLineEdits.h
@@ -1,0 +1,26 @@
+﻿//NameValueLineEdits.h by Emercoin developers
+#pragma once
+#include "SelectableLineEdit.h"
+class SelectableTextEdit;
+
+//Displays NVS (Name-value storage) name and value in line edits, allows to copy them easily.
+class NameValueLineEdits: public QWidget {
+	public:
+		NameValueLineEdits();
+		void setName(const QString & s);
+		void setValue(const QString & s);
+		void setValuePlaceholder(const QString & s);
+		void setValueMultiline(bool b);
+		void setValueReadOnly(bool b);
+		QString name()const;
+		QString value()const;
+	protected:
+		SelectableLineEdit* _resultingName = 0;
+		bool _multiline = false;
+		QWidget* _w1Line = 0;
+		QWidget* _wMultiLine = 0;
+        SelectableLineEdit* _resultingValue = 0;
+		SelectableTextEdit* _resultingMultiline = 0;
+
+		void copyValue();
+};

--- a/src/qt/SelectableLineEdit.cpp
+++ b/src/qt/SelectableLineEdit.cpp
@@ -1,0 +1,22 @@
+﻿//SelectableLineEdit.cpp by Emercoin developers
+#include "SelectableLineEdit.h"
+#include <QApplication>
+#include <QClipboard>
+#include <QToolTip>
+
+void SelectableLineEdit::mousePressEvent(QMouseEvent *e) {
+	QLineEdit::mousePressEvent(e);
+	if(isReadOnly())
+		selectAll();
+}
+void SelectableLineEdit::copyAndShowTooltip(QLineEdit*toDeselect) {
+	if(toDeselect)
+		toDeselect->deselect();
+	selectAll();
+	QApplication::clipboard()->setText(text());
+	QWidget* wNear = _buddyToShowToolip;
+	if(!wNear)
+		wNear = this;
+	auto pt = wNear->rect().bottomLeft();
+	QToolTip::showText(wNear->mapToGlobal(pt), tr("Copied"));
+}

--- a/src/qt/SelectableLineEdit.h
+++ b/src/qt/SelectableLineEdit.h
@@ -1,0 +1,13 @@
+﻿//SelectableLineEdit.h by Emercoin developers
+#pragma once
+#include <QPointer>
+#include <QLineEdit>
+
+class SelectableLineEdit: public QLineEdit {
+	public:
+		SelectableLineEdit() {}
+		virtual void mousePressEvent(QMouseEvent *e)override;
+		void copyAndShowTooltip(QLineEdit*toDeselect = 0);
+		
+		QPointer<QWidget> _buddyToShowToolip;//use this window if not set
+};

--- a/src/qt/managenamespage.cpp
+++ b/src/qt/managenamespage.cpp
@@ -167,10 +167,11 @@ ManageNamesPage::~ManageNamesPage()
 }
 
 void ManageNamesPage::onManageDomainsClicked() {
-    ManageDnsPage manageDnsPage(this);
-    connect(&manageDnsPage, &ManageDnsPage::previewName, this, &ManageNamesPage::setDisplayedName);
-    connect(&manageDnsPage, &ManageDnsPage::previewValue, this, &ManageNamesPage::setDisplayedValue);
-    manageDnsPage.exec();
+	ManageDnsPage dlg(this);
+	if(dlg.exec()==QDialog::Accepted) {
+		setDisplayedName(dlg.name());
+		setDisplayedValue(dlg.value());
+	}
 }
 void ManageNamesPage::setModel(WalletModel *walletModel)
 {


### PR DESCRIPTION
aimed for make it as a better pattern for ongoing similar widgets: removed signals and Q_OBJECT macro (less lines to modify in Makefile.qt.include), -= inner classes like LineEdit (use QLineEdit::objectName), class SelectableLineEdit to separate file, class NameValueLineEdits introduced for reuse in similar widgets.