### PR TITLE
apple m1 compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -388,7 +388,7 @@ case $host in
      fi
 
      AX_CHECK_LINK_FLAG([[-Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -Wl,-headerpad_max_install_names"])
-     CPPFLAGS="$CPPFLAGS -DMAC_OSX -DOBJC_OLD_DISPATCH_PROTOTYPES=0"
+     CPPFLAGS="$CPPFLAGS -DMAC_OSX -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -Wno-implicit-function-declaration"
      OBJCXXFLAGS="$CXXFLAGS"
      ;;
    *linux*)


### PR DESCRIPTION
adds "-Wno-implicit-function-declaration" to the CPPFLAGS in configure.ac to avoid the implicit function declaration errors.

compilation works with these changes